### PR TITLE
Add env flag for Google Play billing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ OPENAI_API_KEY=''
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+
+# Enable Google Play billing integration (yes/no)
+GOOGLE_PLAY_BILLING=no

--- a/src/lib/components/chat/Messages/PaymentButton.svelte
+++ b/src/lib/components/chat/Messages/PaymentButton.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-	export let label = 'Charge Your Account.';
-	export let webPaymentUrl = 'https://www.aibrary.dev/chat/payment?chat=true';
-	let loading = false;
+       import { GOOGLE_PLAY_BILLING } from '$lib/constants';
+
+       export let label = 'Charge Your Account.';
+       export let webPaymentUrl = 'https://www.aibrary.dev/chat/payment?chat=true';
+       let loading = false;
 
 	async function initiatePayment() {
 		try {
 			loading = true;
 
-			if ('getDigitalGoodsService' in window) {
+                       if (GOOGLE_PLAY_BILLING === 'yes' && 'getDigitalGoodsService' in window) {
 
 				// Fetch SKU details
 				const service = await window.getDigitalGoodsService('https://play.google.com/billing');

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,6 +15,7 @@ export const RETRIEVAL_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1/retrieval`;
 
 export const WEBUI_VERSION = APP_VERSION;
 export const WEBUI_BUILD_HASH = APP_BUILD_HASH;
+export const GOOGLE_PLAY_BILLING = GOOGLE_PLAY_BILLING;
 export const REQUIRED_OLLAMA_VERSION = '0.1.16';
 
 export const SUPPORTED_FILE_TYPE = [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,10 +30,11 @@ export default defineConfig({
 			]
 		})
 	],
-	define: {
-		APP_VERSION: JSON.stringify(process.env.npm_package_version),
-		APP_BUILD_HASH: JSON.stringify(process.env.APP_BUILD_HASH || 'dev-build')
-	},
+        define: {
+                APP_VERSION: JSON.stringify(process.env.npm_package_version),
+                APP_BUILD_HASH: JSON.stringify(process.env.APP_BUILD_HASH || 'dev-build'),
+                GOOGLE_PLAY_BILLING: JSON.stringify(process.env.google_play_billing || 'no')
+        },
 	build: {
 		sourcemap: true
 	},


### PR DESCRIPTION
## Summary
- allow toggling Google Play Billing via `GOOGLE_PLAY_BILLING` env var
- default to no billing when the env var is not set
- document the env var in `.env.example`

## Testing
- `npm run test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_685ad7ee2aac832687edd696234ddf4c