### PR TITLE
Make Google Play billing optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ OPENAI_API_KEY=''
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+
+# Enable Google Play billing for Android builds (yes/no)
+GOOGLE_PLAY_BILLING=no

--- a/src/lib/components/chat/Messages/PaymentButton.svelte
+++ b/src/lib/components/chat/Messages/PaymentButton.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-	export let label = 'Charge your account';
-	export let webPaymentUrl = 'https://www.aibrary.dev/chat/payment?chat=true';
-	let loading = false;
+       export let label = 'Charge your account';
+       export let webPaymentUrl = 'https://www.aibrary.dev/chat/payment?chat=true';
+       let loading = false;
+
+       // Whether to use Google Play billing
+       import { GOOGLE_PLAY_BILLING_ENABLED } from '$lib/constants';
 
 	async function initiatePayment() {
 		try {
 			loading = true;
 
-			// Check if Digital Goods API is available
-			if (navigator.digitalGoods && navigator.digitalGoods.getService) {
+                       // Use Google Play billing only when enabled and available
+                       if (GOOGLE_PLAY_BILLING_ENABLED === 'yes' && navigator.digitalGoods && navigator.digitalGoods.getService) {
 				const digitalGoods = await navigator.digitalGoods.getService('play');
 
 				const sku = 'credit_5usd';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,6 +15,8 @@ export const RETRIEVAL_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1/retrieval`;
 
 export const WEBUI_VERSION = APP_VERSION;
 export const WEBUI_BUILD_HASH = APP_BUILD_HASH;
+export const GOOGLE_PLAY_BILLING_ENABLED =
+       (GOOGLE_PLAY_BILLING || 'no').toLowerCase();
 export const REQUIRED_OLLAMA_VERSION = '0.1.16';
 
 export const SUPPORTED_FILE_TYPE = [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,10 +30,11 @@ export default defineConfig({
 			]
 		})
 	],
-	define: {
-		APP_VERSION: JSON.stringify(process.env.npm_package_version),
-		APP_BUILD_HASH: JSON.stringify(process.env.APP_BUILD_HASH || 'dev-build')
-	},
+       define: {
+               APP_VERSION: JSON.stringify(process.env.npm_package_version),
+               APP_BUILD_HASH: JSON.stringify(process.env.APP_BUILD_HASH || 'dev-build'),
+               GOOGLE_PLAY_BILLING: JSON.stringify(process.env.google_play_billing || 'no')
+       },
 	build: {
 		sourcemap: true
 	},


### PR DESCRIPTION
## Summary
- add `GOOGLE_PLAY_BILLING` toggle to `.env.example`
- expose a constant `GOOGLE_PLAY_BILLING_ENABLED` in `constants.ts`
- use the new constant in the payment button logic

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install` *(fails: fetch failed for onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_685b699a6f04832696bc5fb80c4a40f1