### PR TITLE
Disable google play billing by default

### DIFF
--- a/src/lib/components/chat/Messages/PaymentButton.svelte
+++ b/src/lib/components/chat/Messages/PaymentButton.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-	export let label = 'Charge your account';
-	export let webPaymentUrl = 'https://www.aibrary.dev/chat/payment?chat=true';
-	let loading = false;
+        export let label = 'Charge your account';
+        export let webPaymentUrl = 'https://www.aibrary.dev/chat/payment?chat=true';
+        let loading = false;
+
+        const GOOGLE_PLAY_BILLING_ENABLED = GOOGLE_PLAY_BILLING === 'yes';
 
 	async function initiatePayment() {
 		try {
 			loading = true;
 
 			// Check if Digital Goods API is available
-			if (navigator.digitalGoods && navigator.digitalGoods.getService) {
+                        if (GOOGLE_PLAY_BILLING_ENABLED && navigator.digitalGoods && navigator.digitalGoods.getService) {
 				const digitalGoods = await navigator.digitalGoods.getService('play');
 
 				const sku = 'credit_5usd';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,10 +30,11 @@ export default defineConfig({
 			]
 		})
 	],
-	define: {
-		APP_VERSION: JSON.stringify(process.env.npm_package_version),
-		APP_BUILD_HASH: JSON.stringify(process.env.APP_BUILD_HASH || 'dev-build')
-	},
+        define: {
+                APP_VERSION: JSON.stringify(process.env.npm_package_version),
+                APP_BUILD_HASH: JSON.stringify(process.env.APP_BUILD_HASH || 'dev-build'),
+                GOOGLE_PLAY_BILLING: JSON.stringify(process.env.google_play_billing || 'no')
+        },
 	build: {
 		sourcemap: true
 	},


### PR DESCRIPTION
## Summary
- gate the Android Google Play payment path behind a new `google_play_billing` environment variable
- default the new flag to `"no"`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6d5f6be88326b65a642bbf7ddb39